### PR TITLE
Run npm-script `npm run generate` instead of `npm build`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -346,29 +346,16 @@
                 <configuration>
                     <workingDirectory>${basedir}/src/main/resources/nuxt-spa</workingDirectory>
                     <installDirectory>target</installDirectory>
+                    <nodeVersion>v8.11.1</nodeVersion>
+                    <npmVersion>5.6.0</npmVersion>
                 </configuration>
                 <executions>
-                <execution>
-                    <id>install node and npm</id>
-                    <goals>
-                        <goal>install-node-and-npm</goal>
-                    </goals>
-                    <configuration>
-                        <nodeVersion>v8.11.1</nodeVersion>
-                        <npmVersion>5.6.0</npmVersion>
-                    </configuration>
-                </execution>
-                    <!--
                     <execution>
-                        <id>run tests -y</id>
+                        <id>install node and npm</id>
                         <goals>
-                            <goal>npm</goal>
+                            <goal>install-node-and-npm</goal>
                         </goals>
-                        <configuration>
-                            <arguments>test</arguments>
-                        </configuration>
                     </execution>
-                     -->
                     <execution>
                         <id>npm run build -y</id>
                         <goals>
@@ -376,11 +363,10 @@
                         </goals>
                         <configuration>
                             <arguments>
-                               build
+                                run generate
                             </arguments>
                         </configuration>
                     </execution>
-
                 </executions>
             </plugin>
             <plugin>
@@ -431,15 +417,20 @@
                                 </excludes>
                             </artifactSet>
                             <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ComponentsXmlResourceTransformer" />
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ComponentsXmlResourceTransformer"/>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                                     <resource>META-INF/spring.schemas</resource>
                                 </transformer>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                                     <resource>META-INF/spring.handlers</resource>
                                 </transformer>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                                     <resource>META-INF/spring.tooling</resource>
                                 </transformer>
                             </transformers>

--- a/src/main/resources/nuxt-spa/package.json
+++ b/src/main/resources/nuxt-spa/package.json
@@ -8,7 +8,7 @@
     "dev": "set NODE_ENV=dev && nuxt",
     "build": "npm install && nuxt build",
     "start": "set NODE_ENV=dev && nuxt start",
-    "generate": "nuxt generate",
+    "generate": "npm rebuild node-sass && nuxt generate",
     "lint": "eslint --ext .js,.vue --ignore-path .gitignore .",
     "test": "jest",
     "analyze": "nuxt build --analyze"


### PR DESCRIPTION
npm build was a no-op. In order to get nuxt to run locally, node-sass had to regenerate bindings.

Between v10.34.11 and v10.34.12 the `dist` folder is no longer generated and packed together with the jar. 

This PR recreates the dist-folder 