### PR TITLE
Fix/jenkins deps

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -2,6 +2,11 @@
   "extends": ["config:base"],
   "enabled": true,
   "prHourlyLimit": 0,
+  "ignoreDeps": [
+    "floating-vue",
+    "nuxt",
+    "sass-loader"
+  ],
   "packageRules": [
     {
       "matchManagers": ["npm","maven"],

--- a/src/main/resources/nuxt-spa/nuxt.config.js
+++ b/src/main/resources/nuxt-spa/nuxt.config.js
@@ -90,6 +90,16 @@ export default {
         }
       }
     },
+    babel: {
+      presets(env, [preset, options]) {
+        return [
+          ["@babel/preset-env", {
+            ...options,
+            useBuiltIns: "usage"
+          }]
+        ]
+      }
+    },
     /*
     ** You can extend webpack config here
     */

--- a/src/main/resources/nuxt-spa/package-lock.json
+++ b/src/main/resources/nuxt-spa/package-lock.json
@@ -36,7 +36,7 @@
         "jest": "29.5.0",
         "sass": "1.63.2",
         "sass-loader": "10.4.1",
-        "vue-template-compiler": "2.6.14"
+        "vue-template-compiler": "2.7.14"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -4777,15 +4777,6 @@
         "node": "^14.18.0 || ^16.10.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@nuxt/vue-app/node_modules/vue-template-compiler": {
-      "version": "2.7.14",
-      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.14.tgz",
-      "integrity": "sha512-zyA5Y3ArvVG0NacJDkkzJuPQDF8RFeRlzV2vLeSnhSpieO6LK2OVbdLPi5MPPs09Ii+gMO8nY4S3iKQxBxDmWQ==",
-      "dependencies": {
-        "de-indent": "^1.0.2",
-        "he": "^1.2.0"
-      }
-    },
     "node_modules/@nuxt/vue-renderer": {
       "version": "2.16.3",
       "resolved": "https://registry.npmjs.org/@nuxt/vue-renderer/-/vue-renderer-2.16.3.tgz",
@@ -4929,15 +4920,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/@nuxt/webpack/node_modules/vue-template-compiler": {
-      "version": "2.7.14",
-      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.14.tgz",
-      "integrity": "sha512-zyA5Y3ArvVG0NacJDkkzJuPQDF8RFeRlzV2vLeSnhSpieO6LK2OVbdLPi5MPPs09Ii+gMO8nY4S3iKQxBxDmWQ==",
-      "dependencies": {
-        "de-indent": "^1.0.2",
-        "he": "^1.2.0"
       }
     },
     "node_modules/@nuxt/webpack/node_modules/yallist": {
@@ -22011,12 +21993,12 @@
       }
     },
     "node_modules/vue-template-compiler": {
-      "version": "2.6.14",
-      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.14.tgz",
-      "integrity": "sha512-ODQS1SyMbjKoO1JBJZojSw6FE4qnh9rIpUZn2EUT86FKizx9uH5z6uXiIrm4/Nb/gwxTi/o17ZDEGWAXHvtC7g==",
+      "version": "2.7.14",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.14.tgz",
+      "integrity": "sha512-zyA5Y3ArvVG0NacJDkkzJuPQDF8RFeRlzV2vLeSnhSpieO6LK2OVbdLPi5MPPs09Ii+gMO8nY4S3iKQxBxDmWQ==",
       "dependencies": {
         "de-indent": "^1.0.2",
-        "he": "^1.1.0"
+        "he": "^1.2.0"
       }
     },
     "node_modules/vue-template-es2015-compiler": {
@@ -26679,17 +26661,6 @@
         "vue-router": "^3.6.5",
         "vue-template-compiler": "^2.7.14",
         "vuex": "^3.6.2"
-      },
-      "dependencies": {
-        "vue-template-compiler": {
-          "version": "2.7.14",
-          "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.14.tgz",
-          "integrity": "sha512-zyA5Y3ArvVG0NacJDkkzJuPQDF8RFeRlzV2vLeSnhSpieO6LK2OVbdLPi5MPPs09Ii+gMO8nY4S3iKQxBxDmWQ==",
-          "requires": {
-            "de-indent": "^1.0.2",
-            "he": "^1.2.0"
-          }
-        }
       }
     },
     "@nuxt/vue-renderer": {
@@ -26813,15 +26784,6 @@
           "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
           "requires": {
             "lru-cache": "^6.0.0"
-          }
-        },
-        "vue-template-compiler": {
-          "version": "2.7.14",
-          "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.14.tgz",
-          "integrity": "sha512-zyA5Y3ArvVG0NacJDkkzJuPQDF8RFeRlzV2vLeSnhSpieO6LK2OVbdLPi5MPPs09Ii+gMO8nY4S3iKQxBxDmWQ==",
-          "requires": {
-            "de-indent": "^1.0.2",
-            "he": "^1.2.0"
           }
         },
         "yallist": {
@@ -39809,12 +39771,12 @@
       }
     },
     "vue-template-compiler": {
-      "version": "2.6.14",
-      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.14.tgz",
-      "integrity": "sha512-ODQS1SyMbjKoO1JBJZojSw6FE4qnh9rIpUZn2EUT86FKizx9uH5z6uXiIrm4/Nb/gwxTi/o17ZDEGWAXHvtC7g==",
+      "version": "2.7.14",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.14.tgz",
+      "integrity": "sha512-zyA5Y3ArvVG0NacJDkkzJuPQDF8RFeRlzV2vLeSnhSpieO6LK2OVbdLPi5MPPs09Ii+gMO8nY4S3iKQxBxDmWQ==",
       "requires": {
         "de-indent": "^1.0.2",
-        "he": "^1.1.0"
+        "he": "^1.2.0"
       }
     },
     "vue-template-es2015-compiler": {

--- a/src/main/resources/nuxt-spa/package.json
+++ b/src/main/resources/nuxt-spa/package.json
@@ -43,6 +43,6 @@
     "jest": "29.5.0",
     "sass": "1.63.2",
     "sass-loader": "10.4.1",
-    "vue-template-compiler": "2.6.14"
+    "vue-template-compiler": "2.7.14"
   }
 }

--- a/src/main/resources/nuxt-spa/package.json
+++ b/src/main/resources/nuxt-spa/package.json
@@ -9,7 +9,7 @@
     "build": "nuxt build",
     "pre-run": "install-changed",
     "start": "cross-env NODE_ENV=dev && nuxt start",
-    "generate": "nuxt generate",
+    "generate": "NODE_OPTIONS=--openssl-legacy-provider nuxt generate",
     "lint": "eslint --ext .js,.vue --ignore-path .gitignore .",
     "test": "jest",
     "analyze": "nuxt build --analyze"


### PR DESCRIPTION
## Fix build and deps issues

Its important to remember we are using `nuxt/vue 2` which means some updates can't be applied. I've ignore those deps in renovate config:
```
  "ignoreDeps": [
    "floating-vue",
    "nuxt",
    "sass-loader"
  ],
```
Its worth considering upgrading to nuxt 3, might be a good test to do it here, before we do quadim.

To fix a generate issue because of node versions, we either need to downgrade node or use the option `--openssl-legacy-provider` for now, this would probably be fixed with nuxt/vue3 as well.

The only upgrade I did was `vue-template-compiler`, preset/env is also latest, and I fixed build issues